### PR TITLE
Updating to supported version of Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:18.04
 LABEL maintainer="Javier Santos"
 
 ENV VERSION_SDK_TOOLS "3859397"


### PR DESCRIPTION
https://www.ubuntu.com/info/release-end-of-life Ubuntu version 17.04 recently went EOL and you are no longer able to build this image due to missing repositories