### PR TITLE
Add a newline so android-28 is added to the platforms

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -9,3 +9,4 @@ platforms;android-25
 platforms;android-26
 platforms;android-27
 platforms;android-28
+


### PR DESCRIPTION
I found out that without the newline after the last platform, it is not being installed in the created docker image. Adding in the newline allows the last (in this case android-28) to be installed in the sdk/platforms directory.

You can verify that the previous version doesn't work by running 
`docker run -it javiersantos/android-ci:28.0.3 /bin/bash`
 and then `cd /sdk/platforms` and `ls`