### PR TITLE
Apply platforms 28 license

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ RUN curl -s https://dl.google.com/android/repository/sdk-tools-linux-${VERSION_S
 RUN mkdir -p $ANDROID_HOME/licenses/ \
   && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" > $ANDROID_HOME/licenses/android-sdk-license \
   && echo "84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license
+  
+RUN yes | sdkmanager "platforms;android-28"
 
 ADD packages.txt /sdk
 RUN mkdir -p /root/.android && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p $ANDROID_HOME/licenses/ \
   && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" > $ANDROID_HOME/licenses/android-sdk-license \
   && echo "84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license
   
-RUN yes | sdkmanager "platforms;android-28"
+RUN yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-28"
 
 ADD packages.txt /sdk
 RUN mkdir -p /root/.android && \


### PR DESCRIPTION
To solve this one:
```
> Failed to install the following Android SDK packages as some licences have not been accepted.
     platforms;android-28 Android SDK Platform 28
  To build this project, accept the SDK license agreements and install the missing components using the Android Studio SDK Manager.
  Alternatively, to transfer the license agreements from one workstation to another, see http://d.android.com/r/studio-ui/export-licenses.html
```